### PR TITLE
feat: introduce calendar-based study log creation flow

### DIFF
--- a/src/components/common/Calendar/Calendar.styled.ts
+++ b/src/components/common/Calendar/Calendar.styled.ts
@@ -156,18 +156,33 @@ export const CalendarWrapper = styled.div`
 
   .fc .fc-event {
     ${token.typography("caption", "md", "semibold")};
+    display: block;
+    width: calc(100% - 8px);
+    min-height: 22px;
     border: none;
     border-radius: 4px;
-    padding: 2px 6px;
+    padding: 4px 6px;
     margin: 2px 4px;
     cursor: pointer;
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
+    box-sizing: border-box;
+  }
+
+  .fc .fc-h-event .fc-event-main {
+    display: block;
+    width: 100%;
+    height: 100%;
   }
 
   .fc .fc-event:hover {
     background-color: rgb(252, 222, 25);
+  }
+
+  .fc .club-report-selected-event {
+    box-shadow: inset 0 0 0 2px ${token.colors.main.alternative};
+    filter: brightness(0.96);
   }
 
   .fc .fc-event-main {
@@ -226,11 +241,15 @@ export const EventContentWrapper = styled.div`
   display: flex;
   align-items: center;
   gap: 4px;
+  width: 100%;
+  min-height: 14px;
   overflow: hidden;
+  pointer-events: none;
 `;
 
 export const EventLabel = styled.span`
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+  pointer-events: none;
 `;

--- a/src/components/common/Calendar/Calendar.tsx
+++ b/src/components/common/Calendar/Calendar.tsx
@@ -12,9 +12,21 @@ import { useEvent } from '@/hooks/useEvent';
 
 type CalendarProps = {
   readOnly?: boolean;
+  initialDate?: Date | string;
+  selectionMode?: 'default' | 'clubReport';
+  selectedScheduleIds?: number[];
+  showHeaderToolbar?: boolean;
+  onSelectionToggle?: (event: EventInput) => void;
 }
 
-const Calendar: React.FC<CalendarProps> = ({readOnly = false}) => {
+const Calendar: React.FC<CalendarProps> = ({
+  readOnly = false,
+  initialDate,
+  selectionMode = 'default',
+  selectedScheduleIds = [],
+  showHeaderToolbar = true,
+  onSelectionToggle,
+}) => {
   const [selectedEvent, setSelectedEvent] = useState<EventInput | null>(null);
   const [cardPosition, setCardPosition] = useState({ x: 0, y: 0 });
   const [isModalOpen, setIsModalOpen] = useState(false);
@@ -22,6 +34,7 @@ const Calendar: React.FC<CalendarProps> = ({readOnly = false}) => {
   const [selectedEndDate, setSelectedEndDate] = useState<Date | null>(null);
   const [modalMode, setModalMode] = useState<string>('');
   const blockPopover = useRef(false);
+  const isSelectionMode = selectionMode === 'clubReport';
 
   const { eventsInfo, setEventsInfo, isLoading } = useEvent();
 
@@ -98,6 +111,29 @@ const Calendar: React.FC<CalendarProps> = ({readOnly = false}) => {
       if (popover) popover.remove();
     }, 0);
 
+    const clickedEvent = formatApiEvents(clickInfo.event);
+
+    if (isSelectionMode) {
+      const rawScheduleId =
+        clickedEvent.scheduleId ??
+        clickInfo.event.extendedProps?.scheduleId ??
+        clickInfo.event.id;
+      const clickedScheduleId = Number(rawScheduleId);
+
+      if (!Number.isFinite(clickedScheduleId) || clickedScheduleId < 0) return;
+
+      onSelectionToggle?.({
+        ...clickedEvent,
+        scheduleId: clickedScheduleId,
+        extendedProps: {
+          ...clickedEvent.extendedProps,
+          scheduleId: clickedScheduleId,
+        },
+      });
+      setSelectedEvent(null);
+      return;
+    }
+
     if (readOnly) {
       const rect = clickInfo.el.getBoundingClientRect();
       const isMobile = window.innerWidth <= 768;
@@ -105,13 +141,13 @@ const Calendar: React.FC<CalendarProps> = ({readOnly = false}) => {
         x: isMobile ? clickInfo.jsEvent.clientX : rect.right + 10,
         y: isMobile ? clickInfo.jsEvent.clientY : rect.top,
       });
-      setSelectedEvent(formatApiEvents(clickInfo.event));
+      setSelectedEvent(clickedEvent);
       return;
     }
 
     setSelectedDate(null);
     setSelectedEndDate(null);
-    setSelectedEvent(formatApiEvents(clickInfo.event));
+    setSelectedEvent(clickedEvent);
     setIsModalOpen(true);
     setModalMode('편집');
   };
@@ -128,6 +164,21 @@ const Calendar: React.FC<CalendarProps> = ({readOnly = false}) => {
     );
   };
 
+  const calendarEvents = (isLoading ? skeletonEvents : eventsInfo).map((event) => {
+    const scheduleId = event.scheduleId ?? event.extendedProps?.scheduleId;
+    const isSelected = !isLoading && typeof scheduleId === 'number' && selectedScheduleIds.includes(scheduleId);
+    const classNames = [...(Array.isArray((event as any).classNames) ? (event as any).classNames : [])];
+
+    if (isSelected) {
+      classNames.push('club-report-selected-event');
+    }
+
+    return {
+      ...event,
+      classNames,
+    };
+  }) as EventInput[];
+
   return (
     <>
       <S.SkeletonStyle />
@@ -135,12 +186,17 @@ const Calendar: React.FC<CalendarProps> = ({readOnly = false}) => {
         <FullCalendar
           plugins={[dayGridPlugin, interactionPlugin]}
           initialView="dayGridMonth"
-          headerToolbar={{
-            left: 'prev',
-            center: 'title',
-            right: 'next'
-          }}
-          events={isLoading ? skeletonEvents : eventsInfo}
+          headerToolbar={
+            showHeaderToolbar
+              ? {
+                  left: 'prev',
+                  center: 'title',
+                  right: 'next'
+                }
+              : false
+          }
+          initialDate={initialDate}
+          events={calendarEvents}
           editable={!readOnly}
           selectable={!readOnly}
           selectMirror={true}
@@ -179,7 +235,7 @@ const Calendar: React.FC<CalendarProps> = ({readOnly = false}) => {
         />
       </S.CalendarWrapper>
 
-      {readOnly && selectedEvent && (
+      {readOnly && !isSelectionMode && selectedEvent && (
         <EventDetailCard
           event={selectedEvent}
           position={cardPosition}

--- a/src/pages/Study/StudyMentor/StudyMentor.styled.ts
+++ b/src/pages/Study/StudyMentor/StudyMentor.styled.ts
@@ -30,9 +30,10 @@ export const NavHeader = styled.div`
 
 export const NavSide = styled.div`
   min-width: 144px;
-  ${token.flexRow}
+  ${token.flexColumn}
   align-items: center;
-  justify-content: flex-end;
+  justify-content: center;
+  gap: 8px;
 `;
 
 export const NavCenter = styled.div`
@@ -69,15 +70,28 @@ export const NavButton = styled.button`
   }
 `;
 
-export const ReportButton = styled.button`
-  min-width: 144px;
-  height: 40px;
-  padding: 0 18px;
+export const ReportLabelButton = styled.button`
+  border: none;
+  background: transparent;
+  padding: 0;
+  ${token.typography("body", "sm", "semibold")};
+  color: ${token.colors.text.strong};
+  cursor: pointer;
+`;
+
+export const ReportAddButton = styled.img`
+  width: 23px;
+  height: 23px;
+  cursor: pointer;
+`;
+
+export const ReportDetailButton = styled.button`
+  padding: 15px 18px;
+  background-color: ${token.colors.main.alternative};
+  color: ${token.colors.text.neutral};
   border: none;
   border-radius: ${token.shapes.medium};
-  background-color: ${token.colors.main.alternative};
-  color: ${token.colors.main.white};
-  ${token.typography("body", "sm", "semibold")};
+  ${token.typography("body", "sm", "medium")};
   cursor: pointer;
 `;
 

--- a/src/pages/Study/StudyMentor/StudyMentor.tsx
+++ b/src/pages/Study/StudyMentor/StudyMentor.tsx
@@ -2,11 +2,20 @@ import { useCallback, useEffect, useState } from "react";
 import Post from "../components/StudyPost/StudyPost";
 import * as S from "./StudyMentor.styled";
 import { getStudies, type StudyResponse } from "@/api/Study";
-import { getClubReports, type ClubReportResponse } from "@/api/ClubReport";
+import {
+  createClubReport,
+  getClubReports,
+  regenerateClubReport,
+  type ClubReportResponse,
+} from "@/api/ClubReport";
 import LeftArrow from "@/assets/study/Arrow.png";
+import StudyAddButton from "@/assets/study/studyAdd.png";
 import StudyModal from "../components/StudyModal/StudyModal";
 import { getUser } from "@/api/User";
 import { getStudyWeek } from "@/utils/getStudyWeek";
+import type { EventInput } from "@fullcalendar/core";
+import ClubReportCreateModal from "../components/ClubReportCreateModal/ClubReportCreateModal";
+import { toast } from "@/store/toastStore";
 
 function StudyMentorSkeleton() {
   return (
@@ -33,6 +42,9 @@ export default function StudyMentor() {
   const [selectedStudy, setSelectedStudy] = useState<StudyResponse | null>(null);
   const [selectedClubReport, setSelectedClubReport] = useState<ClubReportResponse | null>(null);
   const [isModalOpen, setIsModalOpen] = useState(false);
+  const [isCreateModalOpen, setIsCreateModalOpen] = useState(false);
+  const [selectedScheduleEvents, setSelectedScheduleEvents] = useState<EventInput[]>([]);
+  const [isCreatingClubReport, setIsCreatingClubReport] = useState(false);
   const [role, setRole] = useState<string | null>(null);
 
   // 현재 날짜 기준 초기 값 설정
@@ -104,15 +116,115 @@ export default function StudyMentor() {
   };
 
   const handleOpenClubReport = () => {
-    const matchedReport = clubReports.find(
-      (report) =>
-        Number(report.month) === Number(viewMonth) &&
-        Number(report.weekNumber) === Number(viewWeek),
-    );
-
     setSelectedStudy(null);
-    setSelectedClubReport(matchedReport ?? null);
+    setSelectedClubReport(currentClubReport ?? null);
     setIsModalOpen(true);
+  };
+
+  const handleOpenCreateClubReport = () => {
+    setSelectedScheduleEvents([]);
+    setIsCreateModalOpen(true);
+  };
+
+  const handleRegenerateClubReport = async (clubReport: ClubReportResponse) => {
+    setIsCreatingClubReport(true);
+
+    try {
+      const regeneratedReport = await regenerateClubReport(clubReport.clubReportId);
+
+      setClubReports((prev) => {
+        const filtered = prev.filter(
+          (report) => Number(report.clubReportId) !== Number(clubReport.clubReportId),
+        );
+        return [...filtered, regeneratedReport];
+      });
+      setSelectedClubReport(regeneratedReport);
+    } catch (error) {
+      toast.error("종합 학습일지 재생성에 실패했어요.");
+    } finally {
+      setIsCreatingClubReport(false);
+    }
+  };
+
+  const handleToggleSelectedScheduleEvent = (event: EventInput) => {
+    const scheduleId = Number(event.scheduleId ?? event.extendedProps?.scheduleId);
+
+    if (!Number.isFinite(scheduleId) || scheduleId < 0) {
+      return;
+    }
+
+    if (!event.start) {
+      return;
+    }
+
+    const eventDate = new Date(event.start);
+    const isSameMonth = eventDate.getMonth() + 1 === viewMonth;
+
+    if (!isSameMonth) {
+      toast.warning(`${viewMonth}월 일정만 선택할 수 있어요.`);
+      return;
+    }
+
+    setSelectedScheduleEvents((prev) => {
+      const isAlreadySelected = prev.some(
+        (selectedEvent) =>
+          Number(selectedEvent.scheduleId ?? selectedEvent.extendedProps?.scheduleId) === scheduleId,
+      );
+
+      if (isAlreadySelected) {
+        return prev.filter(
+          (selectedEvent) =>
+            Number(selectedEvent.scheduleId ?? selectedEvent.extendedProps?.scheduleId) !== scheduleId,
+        );
+      }
+
+      return [...prev, event];
+    });
+  };
+
+  const handleCreateClubReport = async () => {
+    if (selectedScheduleEvents.length === 0) {
+      toast.warning("일정을 먼저 선택해 주세요.");
+      return;
+    }
+    const scheduleIds = selectedScheduleEvents
+      .map((event) => event.scheduleId ?? event.extendedProps?.scheduleId)
+      .filter((scheduleId): scheduleId is number => typeof scheduleId === "number");
+
+    if (scheduleIds.length === 0) {
+      toast.error("선택한 일정의 ID를 확인할 수 없어요.");
+      return;
+    }
+
+    setIsCreatingClubReport(true);
+
+    try {
+      const createdReport = await createClubReport({
+        scheduleIds,
+        month: viewMonth,
+        weekNumber: viewWeek,
+      });
+
+      setClubReports((prev) => {
+        const filtered = prev.filter(
+          (report) =>
+            !(
+              Number(report.month) === Number(createdReport.month) &&
+              Number(report.weekNumber) === Number(createdReport.weekNumber)
+            ),
+        );
+        return [...filtered, createdReport];
+      });
+      setSelectedStudy(null);
+      setSelectedClubReport(createdReport);
+      setIsCreateModalOpen(false);
+      setSelectedScheduleEvents([]);
+      setIsModalOpen(true);
+    } catch (error) {
+      toast.error("종합 학습일지 생성에 실패했어요.");
+    } finally {
+      setIsCreatingClubReport(false);
+    }
   };
 
   // 현재 선택된 월/주차에 해당하는 데이터 필터링
@@ -134,6 +246,11 @@ export default function StudyMentor() {
     return Number(finalMonth) === Number(viewMonth) && Number(finalWeek) === Number(viewWeek);
   });
 
+  const currentClubReport = clubReports.find(
+    (report) =>
+      Number(report.month) === Number(viewMonth) &&
+      Number(report.weekNumber) === Number(viewWeek),
+  );
   const isClubReportModal = selectedClubReport !== null || selectedStudy === null;
 
   return (
@@ -150,7 +267,20 @@ export default function StudyMentor() {
           </S.NavButton>
         </S.NavCenter>
         <S.NavSide>
-          <S.ReportButton onClick={handleOpenClubReport}>종합 학습일지</S.ReportButton>
+          {currentClubReport ? (
+            <S.ReportDetailButton onClick={handleOpenClubReport}>종합 학습일지</S.ReportDetailButton>
+          ) : (
+            <>
+              <S.ReportLabelButton onClick={handleOpenClubReport}>
+                종합 학습일지
+              </S.ReportLabelButton>
+              <S.ReportAddButton
+                src={StudyAddButton}
+                alt="종합 학습일지 생성"
+                onClick={handleOpenCreateClubReport}
+              />
+            </>
+          )}
         </S.NavSide>
       </S.NavHeader>
 
@@ -184,12 +314,28 @@ export default function StudyMentor() {
             setSelectedStudy(null);
             setSelectedClubReport(null);
           }}
+          onRegenerateClubReport={handleRegenerateClubReport}
           onSuccess={() => {
             setIsModalOpen(false);
             setSelectedStudy(null);
             setSelectedClubReport(null);
             fetchAllStudies();
           }}
+        />
+      )}
+
+      {isCreateModalOpen && (
+        <ClubReportCreateModal
+          initialDate={new Date(today.getFullYear(), viewMonth - 1, 1)}
+          selectedEvents={selectedScheduleEvents}
+          isSubmitting={isCreatingClubReport}
+          onSelectionToggle={handleToggleSelectedScheduleEvent}
+          onClose={() => {
+            if (isCreatingClubReport) return;
+            setIsCreateModalOpen(false);
+            setSelectedScheduleEvents([]);
+          }}
+          onSubmit={handleCreateClubReport}
         />
       )}
     </S.Container>

--- a/src/pages/Study/components/ClubReportCreateModal/ClubReportCreateModal.styled.ts
+++ b/src/pages/Study/components/ClubReportCreateModal/ClubReportCreateModal.styled.ts
@@ -1,0 +1,72 @@
+import styled from "styled-components";
+import * as token from "@/styles/values/token";
+
+export const Overlay = styled.div`
+  position: fixed;
+  inset: 0;
+  background-color: rgba(0, 0, 0, 0.4);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+`;
+
+export const Container = styled.div`
+  width: min(1100px, 90vw);
+  height: min(800px, 90vh);
+  background-color: ${token.colors.background.white};
+  border: 1px solid ${token.colors.line.normal};
+  border-radius: ${token.shapes.xlarge};
+  padding: 28px;
+  box-sizing: border-box;
+  ${token.flexColumn}
+  gap: 20px;
+`;
+
+export const Header = styled.div`
+  ${token.flexRow}
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+`;
+
+export const TitleGroup = styled.div`
+  ${token.flexColumn}
+`;
+
+export const Title = styled.h2`
+  margin: 0;
+  ${token.typography("body", "lg", "semibold")};
+  color: ${token.colors.text.strong};
+`;
+
+export const CloseButton = styled.img`
+  width: 19px;
+  height: 19px;
+  cursor: pointer;
+`;
+
+export const CalendarSection = styled.div`
+  flex: 1;
+  min-height: 0;
+`;
+
+export const Footer = styled.div`
+  width: 100%;
+`;
+
+export const PrimaryButton = styled.button`
+  width: 100%;
+  padding: 14px 18px;
+  border: none;
+  border-radius: ${token.shapes.medium};
+  background-color: ${token.colors.main.alternative};
+  color: ${token.colors.main.white};
+  ${token.typography("body", "sm", "medium")};
+  cursor: pointer;
+
+  &:disabled {
+    cursor: not-allowed;
+    opacity: 0.5;
+  }
+`;

--- a/src/pages/Study/components/ClubReportCreateModal/ClubReportCreateModal.tsx
+++ b/src/pages/Study/components/ClubReportCreateModal/ClubReportCreateModal.tsx
@@ -1,0 +1,60 @@
+import CommonCalendar from "@/components/common/Calendar/Calendar";
+import type { EventInput } from "@fullcalendar/core";
+import cancelImg from "@/assets/cancel.png";
+import * as S from "./ClubReportCreateModal.styled";
+
+interface ClubReportCreateModalProps {
+  initialDate: Date;
+  selectedEvents: EventInput[];
+  isSubmitting: boolean;
+  onSelectionToggle: (event: EventInput) => void;
+  onClose: () => void;
+  onSubmit: () => void;
+}
+
+export default function ClubReportCreateModal({
+  initialDate,
+  selectedEvents,
+  isSubmitting,
+  onSelectionToggle,
+  onClose,
+  onSubmit,
+}: ClubReportCreateModalProps) {
+  const monthLabel = initialDate.getMonth() + 1;
+  const selectedScheduleIds = selectedEvents
+    .map((event) => event.scheduleId ?? event.extendedProps?.scheduleId)
+    .filter((scheduleId): scheduleId is number => typeof scheduleId === "number");
+
+  return (
+    <S.Overlay>
+      <S.Container onClick={(e) => e.stopPropagation()}>
+        <S.Header>
+          <S.TitleGroup>
+            <S.Title>종합 학습일지 생성 ({monthLabel}월)</S.Title>
+          </S.TitleGroup>
+          <S.CloseButton src={cancelImg} onClick={onClose} />
+        </S.Header>
+
+        <S.CalendarSection>
+          <CommonCalendar
+            readOnly={true}
+            initialDate={initialDate}
+            selectionMode="clubReport"
+            selectedScheduleIds={selectedScheduleIds}
+            showHeaderToolbar={false}
+            onSelectionToggle={onSelectionToggle}
+          />
+        </S.CalendarSection>
+
+        <S.Footer>
+          <S.PrimaryButton
+            onClick={onSubmit}
+            disabled={selectedEvents.length === 0 || isSubmitting}
+          >
+            완료
+          </S.PrimaryButton>
+        </S.Footer>
+      </S.Container>
+    </S.Overlay>
+  );
+}

--- a/src/pages/Study/components/StudyModal/StudyModal.styled.ts
+++ b/src/pages/Study/components/StudyModal/StudyModal.styled.ts
@@ -131,6 +131,39 @@ export const StudyInputdivider = styled.div`
   background-color: ${token.colors.line.normal};
 `
 
+export const ScheduleSection = styled.div`
+  width: 100%;
+  ${token.flexColumn}
+  gap: 8px;
+`;
+
+export const ScheduleList = styled.div`
+  width: 100%;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+`;
+
+export const ScheduleChip = styled.div<{ $backgroundColor?: string }>`
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  max-width: 100%;
+  min-height: 22px;
+  padding: 4px 8px;
+  border-radius: 4px;
+  background-color: ${({ $backgroundColor }) => $backgroundColor || "rgb(252, 222, 25)"};
+  ${token.typography("caption", "md", "semibold")};
+  color: ${token.colors.calendar.black};
+  box-sizing: border-box;
+`;
+
+export const ScheduleChipLabel = styled.span`
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+`;
+
 export const ButtonContainer = styled.div`
   ${token.flexRow}
   width: 100%;
@@ -148,6 +181,15 @@ export const Button = styled.button`
   border-radius: ${token.shapes.medium};
   cursor: pointer;
   border: none;
+
+  &:hover:not(:disabled) {
+    filter: brightness(0.94);
+  }
+
+  &:disabled {
+    cursor: not-allowed;
+    opacity: 0.55;
+  }
 `
 
 export const CancelButton = styled.button`
@@ -158,15 +200,8 @@ export const CancelButton = styled.button`
   border-radius: ${token.shapes.medium};
   cursor: pointer;
   border: none;
-`
 
-export const DeleteButton = styled.button`
-  width: 100%;
-  padding: 10px;
-  background-color: ${token.colors.state.errorSoft};
-  color: ${token.colors.main.white};
-  ${token.typography("body", "sm", "medium")}
-  border-radius: ${token.shapes.medium};
-  cursor: pointer;
-  margin-bottom: 5px;
+  &:hover:not(:disabled) {
+    background-color: ${token.colors.fill.assistive};
+  }
 `

--- a/src/pages/Study/components/StudyModal/StudyModal.tsx
+++ b/src/pages/Study/components/StudyModal/StudyModal.tsx
@@ -1,9 +1,16 @@
 import { useState, useEffect } from "react";
+import { FaFlag } from "react-icons/fa6";
 import * as S from "./StudyModal.styled";
 import cancelImg from "@/assets/cancel.png";
 import { createStudy, updateStudy, deleteStudy, type StudyResponse } from "@/api/Study";
-import type { ClubReportResponse } from "@/api/ClubReport";
+import {
+  type ClubReportResponse,
+} from "@/api/ClubReport";
+import { getEvent } from "@/api/Event";
+import type { Event } from "@/types/fullCalendar";
 import KebabMenu from "@/components/common/KebabMenu/KebabMenu";
+import ConfirmModal from "@/components/common/ConfirmModal/ConfirmModal";
+import { toast } from "@/store/toastStore";
 
 interface StudyModalProps {
   month: number;
@@ -13,6 +20,7 @@ interface StudyModalProps {
   mode?: "study" | "clubReport";
   isReadOnly?: boolean;
   isMentee?: boolean;
+  onRegenerateClubReport?: (clubReport: ClubReportResponse) => Promise<void> | void;
   onClose: () => void;
   onSuccess: () => void;
 }
@@ -25,6 +33,7 @@ export default function StudyModal({
   mode = "study",
   isReadOnly: initialIsReadOnly = false,
   isMentee,
+  onRegenerateClubReport,
   onClose, 
   onSuccess 
 }: StudyModalProps) {
@@ -33,6 +42,7 @@ export default function StudyModal({
   const readOnlyOwnContent = study?.ownContent || fallbackFullContent;
   const readOnlyClubContent = study?.clubContent ?? "";
   const reportContent = clubReport?.activityContent ?? "";
+  const scheduleTitles = clubReport?.scheduleTitles ?? [];
 
   // 데이터가 없으면 작성 모드로 시작
   const [isReadOnly, setIsReadOnly] = useState(study ? initialIsReadOnly : false);
@@ -40,6 +50,10 @@ export default function StudyModal({
   const [ownContent, setOwnContent] = useState(study?.ownContent ?? fallbackFullContent);
   const [clubContent, setClubContent] = useState(study?.clubContent ?? "");
   const [isLoading, setIsLoading] = useState(false);
+  const [isRegenerateDisabled, setIsRegenerateDisabled] = useState(false);
+  const [isScheduleLoading, setIsScheduleLoading] = useState(false);
+  const [isDeleteConfirmOpen, setIsDeleteConfirmOpen] = useState(false);
+  const [scheduleEvents, setScheduleEvents] = useState<Event[]>([]);
   const MAX_LENGTH = 1000;
   const resolvedMonth = Number(study?.month ?? study?.month_number ?? month);
   const resolvedWeekNumber = Number(study?.weekNumber ?? study?.week_number ?? weekNumber);
@@ -51,6 +65,34 @@ export default function StudyModal({
     setOwnContent(study?.ownContent ?? study?.fullContent ?? "");
     setClubContent(study?.clubContent ?? "");
   }, [initialIsReadOnly, study]);
+
+  useEffect(() => {
+    if (!isClubReportMode || !clubReport || clubReport.scheduleIds.length === 0) {
+      setIsScheduleLoading(false);
+      setScheduleEvents([]);
+      return;
+    }
+
+    const fetchScheduleEvents = async () => {
+      setIsScheduleLoading(true);
+      try {
+        const schedules = await getEvent();
+        const matchedSchedules = clubReport.scheduleIds
+          .map((scheduleId) =>
+            schedules.find((schedule) => Number(schedule.scheduleId) === Number(scheduleId)),
+          )
+          .filter((schedule): schedule is Event => Boolean(schedule));
+
+        setScheduleEvents(matchedSchedules);
+      } catch {
+        setScheduleEvents([]);
+      } finally {
+        setIsScheduleLoading(false);
+      }
+    };
+
+    fetchScheduleEvents();
+  }, [clubReport, isClubReportMode]);
 
   const handleSubmit = async () => {
     if (isReadOnly) return;
@@ -76,7 +118,7 @@ export default function StudyModal({
       }
       onSuccess();
     } catch (e) {
-      alert("저장에 실패했어요.");
+      toast.error("저장에 실패했어요.");
     } finally {
       setIsLoading(false);
     }
@@ -84,15 +126,15 @@ export default function StudyModal({
 
   const handleDelete = async () => {
     if (!study) return;
-    if (!window.confirm("이 학습 일지를 삭제하시겠습니까?")) return;
 
     setIsLoading(true);
     try {
       const id = study.studyId ?? (study as any).study_id;
       await deleteStudy(id);
+      setIsDeleteConfirmOpen(false);
       onSuccess();
     } catch (e) {
-      alert("삭제에 실패했어요.");
+      toast.error("삭제에 실패했어요.");
     } finally {
       setIsLoading(false);
     }
@@ -111,7 +153,7 @@ export default function StudyModal({
     }
   };
 
-  const kebabItems = [
+  const studyKebabItems = [
     {
       label: "수정",
       onClick: () => {
@@ -121,19 +163,39 @@ export default function StudyModal({
     {
       label: "삭제",
       onClick: () => {
-        handleDelete();
+        setIsDeleteConfirmOpen(true);
       },
     },
   ];
+
+  const handleRegenerateClick = async () => {
+    if (!clubReport || !onRegenerateClubReport || isRegenerateDisabled) return;
+
+    setIsRegenerateDisabled(true);
+    const startedAt = Date.now();
+
+    try {
+      await onRegenerateClubReport(clubReport);
+    } finally {
+      const elapsed = Date.now() - startedAt;
+      const remaining = Math.max(3000 - elapsed, 0);
+
+      window.setTimeout(() => {
+        setIsRegenerateDisabled(false);
+      }, remaining);
+    }
+  };
 
   return (
     <S.Overlay>
       <S.Container onClick={(e) => e.stopPropagation()}>
         <S.TitleCancelContainer>
-          {isReadOnly && study && isMentee ? (
+          {isClubReportMode ? (
+            <S.Wrapper />
+          ) : isReadOnly && study && isMentee ? (
             <S.KebabWrapper>
               <KebabMenu
-                items={kebabItems}
+                items={studyKebabItems}
                 trigger={
                   <S.KebabIcon>
                     <div /><div /><div />
@@ -162,6 +224,28 @@ export default function StudyModal({
             />
             <S.StudyInputdivider />
           </S.StudyInputContainer>
+        )}
+
+        {isClubReportMode && !isScheduleLoading && scheduleTitles.length > 0 && (
+          <S.ScheduleSection>
+            <S.ScheduleList>
+              {scheduleTitles.map((scheduleTitle, index) => {
+                const scheduleEvent = scheduleEvents.find(
+                  (event) =>
+                    Number(event.scheduleId) === Number(clubReport?.scheduleIds[index]),
+                );
+
+                return (
+                <S.ScheduleChip
+                  key={`${scheduleTitle}-${index}`}
+                  $backgroundColor={scheduleEvent?.color}
+                >
+                  <FaFlag size={12} style={{ flexShrink: 0 }} />
+                  <S.ScheduleChipLabel>{scheduleTitle}</S.ScheduleChipLabel>
+                </S.ScheduleChip>
+              )})}
+            </S.ScheduleList>
+          </S.ScheduleSection>
         )}
 
         {isClubReportMode ? (
@@ -205,7 +289,17 @@ export default function StudyModal({
           </S.InputContainer>
         )}
         
-        {isClubReportMode || isReadOnly ? (
+        {isClubReportMode ? (
+          <S.ButtonContainer>
+            <S.Button
+              onClick={handleRegenerateClick}
+              disabled={isLoading || isRegenerateDisabled}
+            >
+              재생성
+            </S.Button>
+            <S.CancelButton onClick={onClose}>닫기</S.CancelButton>
+          </S.ButtonContainer>
+        ) : isReadOnly ? (
           <S.Button onClick={onClose}>닫기</S.Button>
         ) : (
           <S.ButtonContainer>
@@ -216,6 +310,14 @@ export default function StudyModal({
           </S.ButtonContainer>
         )}
       </S.Container>
+      <ConfirmModal
+        open={isDeleteConfirmOpen}
+        message="이 학습 일지를 삭제하시겠습니까?"
+        cancelLabel="취소"
+        confirmLabel="삭제"
+        onCancel={() => setIsDeleteConfirmOpen(false)}
+        onConfirm={handleDelete}
+      />
     </S.Overlay>
   );
 }

--- a/src/types/fullCalendar.d.ts
+++ b/src/types/fullCalendar.d.ts
@@ -31,6 +31,7 @@ declare module '@fullcalendar/core' {
   }
   
   export interface EventApi {
+    id?: string;
     title: string;
     start: Date | null;
     end: Date | null;
@@ -50,6 +51,7 @@ declare module '@fullcalendar/core' {
   }
 
   export interface EventInput {
+    id?: string;
     title: string;
     date?: string;
     start?: string;

--- a/src/utils/formatEvent.ts
+++ b/src/utils/formatEvent.ts
@@ -7,12 +7,14 @@ export const formatEvents = (events: Event[]): EventInput[] => {
         endDate.setDate(endDate.getDate() + 1); // 하루 추가
         
         return {
+            id: String(event.scheduleId),
             title: event.title,
             start: event.startDate,
             end: endDate.toISOString(),
             color: event.color,
             scheduleId: event.scheduleId,
             extendedProps: {
+                scheduleId: event.scheduleId,
                 description: event.content,
                 assignees: event.users,
             }
@@ -21,15 +23,21 @@ export const formatEvents = (events: Event[]): EventInput[] => {
 };
 
 export const formatApiEvents = (event: EventApi): EventInput => {
+    const scheduleId = Number(
+        event.extendedProps?.scheduleId ?? event.id ?? -1
+    );
+
     return {
+        id: String(scheduleId),
         title: event.title,
         start: event.start?.toISOString() ?? undefined,
         end: event.end?.toISOString() ?? event.start?.toISOString(),
         color: event.backgroundColor,
-        scheduleId: event.extendedProps.scheduleId,
+        scheduleId,
         extendedProps: {
-            description: event.extendedProps.description,
-            assignees: event.extendedProps.assignees,
+            scheduleId,
+            description: event.extendedProps?.description,
+            assignees: event.extendedProps?.assignees,
         }
     }
 }


### PR DESCRIPTION
## #149

### Task
- 종합 학습일지 생성 흐름을 캘린더 선택 방식으로 변경
- 조회 모달 및 재생성 동작 개선
- 공용 캘린더 선택 모드 추가

### Screenshot
<img width="1512" height="762" alt="Screenshot 2026-04-03 at 12 39 15 PM" src="https://github.com/user-attachments/assets/58bca916-150e-429d-a7bb-49a5386741da" />
<img width="1512" height="942" alt="Screenshot 2026-04-03 at 12 39 38 PM" src="https://github.com/user-attachments/assets/7d65c569-e8c2-4589-b6b5-525b19287038" />
<img width="1512" height="942" alt="Screenshot 2026-04-03 at 12 39 53 PM" src="https://github.com/user-attachments/assets/327c798c-73c0-46dc-a903-46d9d24b4d00" />


---
### Checklist
> 해당되는 항목에 모두 체크해주세요.

- [x] 커밋 메시지 컨벤션을 지켰습니다.
- [x] 기능/버그 수정에 대해 테스트를 완료했습니다.