### PR TITLE
hotfix: add year to study requests

### DIFF
--- a/src/api/study.ts
+++ b/src/api/study.ts
@@ -10,6 +10,7 @@ export interface StudyResponse {
   clubContent: string;
   fullContent: string;
   summary: string;
+  year: number;
   month: number;
   month_number?: number;
   weekNumber: number;
@@ -18,6 +19,7 @@ export interface StudyResponse {
 }
 
 export interface CreateStudyRequest {
+  year: number;
   month: number;
   weekNumber: number;
   title: string;
@@ -26,6 +28,7 @@ export interface CreateStudyRequest {
 }
 
 export interface UpdateStudyRequest {
+  year: number;
   month: number;
   weekNumber: number;
   title: string;

--- a/src/pages/Study/StudyMain/StudyMain.tsx
+++ b/src/pages/Study/StudyMain/StudyMain.tsx
@@ -106,12 +106,16 @@ export default function StudyMain() {
           key={month}
           month={month}
           studies={studies.filter((s: any) => {
+            let sYear = s.year;
+            if ((sYear === undefined || sYear === null) && s.createdAt) {
+              sYear = getStudyPeriod(new Date(s.createdAt)).year;
+            }
             // month 필드가 있으면 우선 사용, 없으면 제출 주간 기준으로 계산 (최후의 수단)
             let sMonth = s.month ?? s.month_number ?? s.monthNumber;
             if (sMonth === undefined && s.createdAt) {
               sMonth = getStudyPeriod(new Date(s.createdAt)).month;
             }
-            return Number(sMonth) === Number(month);
+            return Number(sYear) === Number(currentYear) && Number(sMonth) === Number(month);
           })}
           currentMonth={currentMonth}
           currentWeek={currentWeek}

--- a/src/pages/Study/StudyMentor/StudyMentor.tsx
+++ b/src/pages/Study/StudyMentor/StudyMentor.tsx
@@ -69,6 +69,20 @@ export default function StudyMentor() {
     return NaN;
   };
 
+  const getResolvedStudyYear = (study: any) => {
+    const studyYear = study.year;
+
+    if (studyYear !== undefined && studyYear !== null) {
+      return Number(studyYear);
+    }
+
+    if (study.createdAt) {
+      return getStudyPeriod(new Date(study.createdAt)).year;
+    }
+
+    return NaN;
+  };
+
   const getResolvedStudyWeek = (study: any) => {
     const studyWeek = study.weekNumber ?? study.week_number ?? study.week;
 
@@ -285,10 +299,15 @@ export default function StudyMentor() {
   const filteredStudies = Array.from(
     studies
       .filter((study: any) => {
+        const studyYear = getResolvedStudyYear(study);
         const studyMonth = getResolvedStudyMonth(study);
         const studyWeek = getResolvedStudyWeek(study);
 
-        return Number(studyMonth) === Number(viewMonth) && Number(studyWeek) === Number(viewWeek);
+        return (
+          Number(studyYear) === Number(viewYear) &&
+          Number(studyMonth) === Number(viewMonth) &&
+          Number(studyWeek) === Number(viewWeek)
+        );
       })
       .reduce((acc, study: any) => {
         const authorKey = getStudyAuthorKey(study);
@@ -359,6 +378,7 @@ export default function StudyMentor() {
 
       {isModalOpen && (selectedStudy || isClubReportModal) && (
         <StudyModal
+          year={viewYear}
           month={viewMonth}
           weekNumber={viewWeek}
           study={selectedStudy}

--- a/src/pages/Study/components/MonthItem/MonthBar.tsx
+++ b/src/pages/Study/components/MonthItem/MonthBar.tsx
@@ -85,6 +85,7 @@ export default function MonthBar({
 
       {isModalOpen && selectedWeek !== null && (
         <StudyModal
+          year={currentYear}
           month={month}
           weekNumber={selectedWeek}
           study={selectedStudy}

--- a/src/pages/Study/components/StudyModal/StudyModal.tsx
+++ b/src/pages/Study/components/StudyModal/StudyModal.tsx
@@ -13,6 +13,7 @@ import ConfirmModal from "@/components/common/ConfirmModal/ConfirmModal";
 import { toast } from "@/store/toastStore";
 
 interface StudyModalProps {
+  year: number;
   month: number;
   weekNumber: number;
   study?: StudyResponse | null;
@@ -26,6 +27,7 @@ interface StudyModalProps {
 }
 
 export default function StudyModal({ 
+  year,
   month, 
   weekNumber, 
   study, 
@@ -55,6 +57,7 @@ export default function StudyModal({
   const [isDeleteConfirmOpen, setIsDeleteConfirmOpen] = useState(false);
   const [scheduleEvents, setScheduleEvents] = useState<Event[]>([]);
   const MAX_LENGTH = 1000;
+  const resolvedYear = Number(study?.year ?? year);
   const resolvedMonth = Number(study?.month ?? study?.month_number ?? month);
   const resolvedWeekNumber = Number(study?.weekNumber ?? study?.week_number ?? weekNumber);
 
@@ -102,6 +105,7 @@ export default function StudyModal({
         const id = study.studyId ?? (study as any).study_id;
         await updateStudy(id, {
           title,
+          year: resolvedYear,
           month: resolvedMonth,
           weekNumber: resolvedWeekNumber,
           ownContent,
@@ -110,6 +114,7 @@ export default function StudyModal({
       } else {
         await createStudy({
           title,
+          year,
           month,
           weekNumber,
           ownContent,


### PR DESCRIPTION
학습일지 생성/수정 요청에 year를 추가하고, 조회 필터도 연도 기준까지 포함되도록 수정