### PR TITLE
hotfix: align study week range with backend

### DIFF
--- a/src/utils/getStudyWeek.ts
+++ b/src/utils/getStudyWeek.ts
@@ -1,38 +1,42 @@
-const MONDAY = 1;
-const SUNDAY = 0;
+const SATURDAY = 6;
+const FRIDAY = 5;
 
-function getMondayOffset(year: number, month: number) {
+function getSaturdayOffset(year: number, month: number) {
   const firstDayOfMonth = new Date(year, month - 1, 1).getDay();
-  return (firstDayOfMonth - MONDAY + 7) % 7;
+  return (firstDayOfMonth - SATURDAY + 7) % 7;
 }
 
 export function getStudyStart(date: Date) {
   const start = new Date(date);
-  const daysSinceMonday = (start.getDay() - MONDAY + 7) % 7;
-  start.setDate(start.getDate() - daysSinceMonday);
+  const daysSinceSaturday = (start.getDay() - SATURDAY + 7) % 7;
+  start.setDate(start.getDate() - daysSinceSaturday);
   return start;
 }
 
 export function getStudyEnd(date: Date) {
   const end = new Date(date);
-  const daysUntilSunday = (SUNDAY - end.getDay() + 7) % 7;
-  end.setDate(end.getDate() + daysUntilSunday);
+  const daysUntilFriday = (FRIDAY - end.getDay() + 7) % 7;
+  end.setDate(end.getDate() + daysUntilFriday);
   return end;
 }
 
 export function getStudyPeriod(date: Date) {
-  const weekEnd = getStudyEnd(date);
-  const year = weekEnd.getFullYear();
-  const month = weekEnd.getMonth() + 1;
-  const mondayOffset = getMondayOffset(year, month);
-  const weekNumber = Math.ceil((weekEnd.getDate() + mondayOffset) / 7);
+  const weekStart = getStudyStart(date);
+  const year = weekStart.getFullYear();
+  const month = weekStart.getMonth() + 1;
+  const firstDayOfMonth = new Date(year, month - 1, 1);
+  const calendarStart = new Date(firstDayOfMonth);
+  const daysSinceSaturday = getSaturdayOffset(year, month);
+  calendarStart.setDate(calendarStart.getDate() - daysSinceSaturday);
+  const diffTime = weekStart.getTime() - calendarStart.getTime();
+  const weekNumber = Math.floor(diffTime / (7 * 24 * 60 * 60 * 1000)) + 1;
 
   return {
     year,
     month,
     weekNumber,
-    start: getStudyStart(date),
-    end: weekEnd,
+    start: weekStart,
+    end: getStudyEnd(date),
   };
 }
 
@@ -41,7 +45,14 @@ export function getStudyWeek(date: Date) {
 }
 
 export function getStudyWeeksInMonth(year: number, month: number) {
-  const mondayOffset = getMondayOffset(year, month);
-  const lastDateOfMonth = new Date(year, month, 0).getDate();
-  return Math.ceil((lastDateOfMonth + mondayOffset) / 7);
+  const firstDayOfMonth = new Date(year, month - 1, 1);
+  const calendarStart = new Date(firstDayOfMonth);
+  const daysSinceSaturday = getSaturdayOffset(year, month);
+  calendarStart.setDate(calendarStart.getDate() - daysSinceSaturday);
+
+  const lastDayOfMonth = new Date(year, month, 0);
+  const lastWeekStart = getStudyStart(lastDayOfMonth);
+  const diffTime = lastWeekStart.getTime() - calendarStart.getTime();
+
+  return Math.floor(diffTime / (7 * 24 * 60 * 60 * 1000)) + 1;
 }


### PR DESCRIPTION
학습일지 주차 계산 기준을 프론트의 월~일에서 백엔드와 동일한 토~금 기준으로 변경